### PR TITLE
hotfix/모바일 뷰에서 박스가 화면을 벗어나는 에러 수정

### DIFF
--- a/src/components/atom/Tag.tsx
+++ b/src/components/atom/Tag.tsx
@@ -23,7 +23,7 @@ interface TagStyledProps {
 }
 
 const Container = styled.div<TagStyledProps>`
-  width: 67px;
+  width: 100%;
   height: 22px;
   border-radius: 4px;
   margin-right: 8px;


### PR DESCRIPTION
## 작업한 내용

태그 스타일에 고정값이 되어있어서 고침

## 개선된 부분

태그 width를 px -> %